### PR TITLE
feat: 添加移动频道播报功能

### DIFF
--- a/config/config/config.d.ts
+++ b/config/config/config.d.ts
@@ -13,4 +13,5 @@ export interface Config {
   RECONNECT_TIMER: number //断线重连次数 -1表示将不断尝试
   DIS_NOTIFY_NAME_LIST: string[] //不提醒的昵称列表 可多个 默认不提醒当前加入ts的机器人
   SERVER_NAME: string //展示的服务器名
+  ENABLE_CHANNEL_MOVE_NOTIFY: string //是否开启移动频道播报功能 ("true" | "false")
 }

--- a/config/config/config.json
+++ b/config/config/config.json
@@ -14,5 +14,6 @@
   "DIS_NOTIFY_NAME_LIST": [
     "TESTBOT"
   ],
-  "SERVER_NAME": "xxxxxxx"
+  "SERVER_NAME": "xxxxxxx",
+  "ENABLE_CHANNEL_MOVE_NOTIFY": "true"
 }

--- a/src/apps/ts3.ts
+++ b/src/apps/ts3.ts
@@ -62,6 +62,17 @@ class ts3 {
         }
       }
     })
+    // 监听用户移动频道事件
+    _teamspeak.on("clientmoved", (e) => {
+      if (TS.ENABLE_CHANNEL_MOVE_NOTIFY === "true" && e.client && !disNotifyNameList.includes(e.client.nickname)) {
+        logger.info(loggerPluginName + e.client.nickname + "移动到频道: " + e.channel.name)
+        const msg = segment.text(e.client.nickname + "移动到频道: " + e.channel.name)
+        TS.NOTICE_GROUP_NO.forEach((groupNo) => {
+          const contact = karin.contact("group", groupNo + "")
+          karin.sendMsg(karin.getBotAll()[1].account.selfId, contact, msg)
+        })
+      }
+    })
   }
   //获取ts3服务器的所有对应频道的人 -- 并组装成文字可直接发
   getAllChannelList = async () => {
@@ -223,7 +234,7 @@ export const getAllUserList = async () => {
   }
 }
 const router = express.Router()
-router.get("/getAllUserList", async (req, res) => {
+router.get("/getAllUserList", async (req: express.Request, res: express.Response) => {
   const result = await getAllUserList()
   res.send(result)
 })

--- a/src/web.config.ts
+++ b/src/web.config.ts
@@ -113,6 +113,27 @@ export default {
       },
       data: [...config().DIS_NOTIFY_NAME_LIST],
     }),
+    components.radio.group("ENABLE_CHANNEL_MOVE_NOTIFY", {
+      defaultValue: config().ENABLE_CHANNEL_MOVE_NOTIFY ? "true" : "false",
+      label: "移动频道播报功能",
+      description: "当用户在Teamspeak中移动频道时自动播报",
+      size: "sm",
+      orientation: "horizontal",
+      radio: [
+        {
+          componentType: "radio",
+          key: "ENABLE_CHANNEL_MOVE_NOTIFY_TRUE",
+          value: "true",
+          label: "开启",
+        },
+        {
+          componentType: "radio",
+          key: "ENABLE_CHANNEL_MOVE_NOTIFY_FALSE",
+          value: "false",
+          label: "关闭",
+        },
+      ],
+    }),
   ],
 
   /** 前端点击保存之后调用的方法 */


### PR DESCRIPTION
## 功能描述

添加了用户移动频道播报功能，当用户在 Teamspeak 中移动频道时自动播报。

## 主要改动

- 新增 `ENABLE_CHANNEL_MOVE_NOTIFY` 配置项
- 在 Web UI 中添加移动频道播报开关
- 实现 `clientmoved` 事件监听和播报功能
- 支持通过配置文件或 Web UI 控制功能开关

## 修改的文件

- `config/config/config.d.ts` - 添加配置类型定义
- `config/config/config.json` - 添加默认配置值
- `src/web.config.ts` - 添加 Web UI 配置组件
- `src/apps/ts3.ts` - 实现移动频道播报逻辑

## 测试

- [x] 功能开关正常工作
- [x] Web UI 配置界面正常显示
- [x] 移动频道播报功能正常触发

## 使用说明

1. 在 Web UI 中找到"移动频道播报功能"选项
2. 选择"开启"或"关闭"
3. 保存配置
4. 当用户移动频道时，机器人会自动播报消息